### PR TITLE
feat: annotate created Services with kube-vip.io/allow-reconcile-without-endpoints

### DIFF
--- a/controllers/haegressgatewaypolicies_controller.go
+++ b/controllers/haegressgatewaypolicies_controller.go
@@ -258,6 +258,10 @@ func (r *HAEgressGatewayPolicyReconciler) UpdateOrCreateService(ctx context.Cont
 	service.Labels[haegressip.KubernetesServiceProxyNameAnnotation] = "kubevip-managed-by-cilium-haegess"
 	service.Labels[haegressip.HAEgressGatewayPolicyNamespace] = serviceNamespace
 	service.Labels[haegressip.HAEgressGatewayPolicyName] = haEgressGatewayPolicy.Name
+	// The service intentionally has no endpoints, kube-vip >= v1.2.1 only 
+	// reconciles (and BGP-advertises) endpointless services when this
+	// annotation is present
+	service.Annotations[haegressip.KubeVIPAllowReconcileWithoutEndpoints] = "true"
 
 	// Set HAEgressGatewayPolicy instance as the owner and controller
 	if err := controllerutil.SetControllerReference(haEgressGatewayPolicy, service, r.Scheme); err != nil {
@@ -300,6 +304,14 @@ func (r *HAEgressGatewayPolicyReconciler) UpdateOrCreateService(ctx context.Cont
 				(found.Spec.LoadBalancerClass != nil && loadBalancerClassPtr == nil) ||
 				(found.Spec.LoadBalancerClass != nil && loadBalancerClassPtr != nil && *found.Spec.LoadBalancerClass != *loadBalancerClassPtr) {
 				found.Spec.LoadBalancerClass = loadBalancerClassPtr
+				needsUpdate = true
+			}
+
+			if found.Annotations[haegressip.KubeVIPAllowReconcileWithoutEndpoints] != "true" {
+				if found.Annotations == nil {
+					found.Annotations = make(map[string]string)
+				}
+				found.Annotations[haegressip.KubeVIPAllowReconcileWithoutEndpoints] = "true"
 				needsUpdate = true
 			}
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -9,6 +9,7 @@ const (
 	NodeNameAnnotation                               = "kubernetes.io/hostname"
 	EventEgressUpdateReason                          = "Updated"
 	KubeVIPVipHostAnnotation                         = "kube-vip.io/vipHost"
+	KubeVIPAllowReconcileWithoutEndpoints			 = "kube-vip.io/allow-reconcile-without-endpoints"
 	KubernetesServiceProxyNameAnnotation             = "service.kubernetes.io/service-proxy-name"
 
 	LeaseCheckRequeueAfter                 = 10 * time.Second


### PR DESCRIPTION
## What this changes

The operator now sets the annotation `kube-vip.io/allow-reconcile-without-endpoints: "true"` on the LoadBalancer Services it creates, and adds it to already-existing Services during reconciliation (so existing deployments pick it up on operator upgrade, without recreating the Services).

## Why

The Services created by this operator intentionally have no endpoints - as the code itself puts it, they are a "serviceless service used to create the Ip object". Their only job is to make kube-vip allocate and announce the egress IP.

Recent kube-vip versions broke this pattern:

- **kube-vip v1.2.0** - the service-handling refactor (kube-vip/kube-vip#1463) gates per-service processing (including per-service leader election and BGP route advertisement)  on the WService having ready endpoints. `StartServicesLeaderElection`blocks on an ÈndpointsReady`signal that is only fired by the endpoint watcher once endpoints exist. For the operator's endpointless Services this never happens: kube-vip assigns the VIP but **never advertises it**, silently breaking HA egress. 
- **kube-vip v1.2.1** - Added an explicit opt-in for exactly this use case (kube-vip/kube-vip#1578): Services annotated with `kube-vip.io/allow-reconcile-without-endpoints: "true"` (and with `externalTrafficPolicy: Clsuter` - the default, which the operator's Services use) are reconciled and advertised even with zero endpoints. 

Since every Service this operator creates is endpointless by design, the operator should always set this annotation rather tahn requiring users to add it to every `HAEgressGatewayPolicy`. The operator does copy policy annotations onto the Service, so annotating each policy works as a manual workaround - but it is easy to miss and the failure mode is silent (the VIP is assigned, nothing is advertised, egress traffic just stops). 

The annotation is harmless for kube-vip < v1.2.1 (unknown annotations are ignored), so this is safe regardless of the kube-vip version in use.

## Related

For BGP users this pairs with kube-vip/kube-vip#1644 (released in kube-vip v1.2.2), which restores optionally attaching BGP-advertised service VIPs to an interface (`bgp_attach_ip_to_interface=true`) - attachment was removed in v1.1.0 (kube-vip/kube-vip#1442) and is needed for Cilium Egress Gateway to select the egress IP on the gateway node. The combination of that flag plus this annotation is what makes BGP HA egress work again on kube-vip >= v1.2.2.

